### PR TITLE
Fix Linux build portability and C23 compatibility

### DIFF
--- a/.github/workflows/build_linux_x86.yml
+++ b/.github/workflows/build_linux_x86.yml
@@ -4,12 +4,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read    
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-    
 
 jobs:
   build:
@@ -17,20 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-           python-version: '3.10' 
+          python-version: "3.10"
 
       # Runs a set of commands using the runners shell
-      - name: Build-commands
+      - name: Build commands
+        working-directory: ./src
+        env:
+          PORTABLE: "1"
         run: |
-          cd $GITHUB_WORKSPACE/src
           chmod u+x ./build_linux_x86.bash
           ./build_linux_x86.bash
+          ../bin/reseek -h >/dev/null
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: reseek-linux-x86
-          path: /home/runner/work/reseek/reseek/bin/reseek
+          path: ${{ github.workspace }}/bin/reseek
+          if-no-files-found: error

--- a/src/build_linux_x86.bash
+++ b/src/build_linux_x86.bash
@@ -1,8 +1,16 @@
-commit=`cat vcxproj_make_commit.txt`
+#!/usr/bin/env bash
+set -euo pipefail
 
-curl -fsSL https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxproj_make.py \
+commit=$(cat vcxproj_make_commit.txt)
+
+curl -fsSL "https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxproj_make.py" \
   > vcxproj_make.py
 
 mkdir -p ../bin
 
-python3 ./vcxproj_make.py
+portable_opt=""
+if [ "${PORTABLE:-0}" = "1" ]; then
+  portable_opt="--nonative"
+fi
+
+python3 ./vcxproj_make.py --ccompiler "gcc -std=gnu17" $portable_opt

--- a/src/build_linux_x86.bash
+++ b/src/build_linux_x86.bash
@@ -8,9 +8,9 @@ curl -fsSL "https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxpr
 
 mkdir -p ../bin
 
-portable_opt=""
+cmd=(python3 ./vcxproj_make.py --ccompiler "gcc -std=gnu17")
 if [ "${PORTABLE:-0}" = "1" ]; then
-  portable_opt="--nonative"
+  cmd+=(--nonative --cppcompiler "g++ -mavx2")
 fi
 
-python3 ./vcxproj_make.py --ccompiler "gcc -std=gnu17" $portable_opt
+"${cmd[@]}"

--- a/src/build_linux_x86d.bash
+++ b/src/build_linux_x86d.bash
@@ -8,9 +8,9 @@ curl -fsSL "https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxpr
 
 mkdir -p ../bin
 
-portable_opt=""
+cmd=(python3 ./vcxproj_make.py --debug --binary reseekd --ccompiler "gcc -std=gnu17")
 if [ "${PORTABLE:-0}" = "1" ]; then
-  portable_opt="--nonative"
+  cmd+=(--nonative --cppcompiler "g++ -mavx2")
 fi
 
-python3 ./vcxproj_make.py --debug --binary reseekd --ccompiler "gcc -std=gnu17" $portable_opt
+"${cmd[@]}"

--- a/src/build_linux_x86d.bash
+++ b/src/build_linux_x86d.bash
@@ -1,8 +1,16 @@
-commit=`cat vcxproj_make_commit.txt`
+#!/usr/bin/env bash
+set -euo pipefail
 
-curl -fsSL https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxproj_make.py \
+commit=$(cat vcxproj_make_commit.txt)
+
+curl -fsSL "https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxproj_make.py" \
   > vcxproj_make.py
 
 mkdir -p ../bin
 
-python3 ./vcxproj_make.py --debug -binary reseekd
+portable_opt=""
+if [ "${PORTABLE:-0}" = "1" ]; then
+  portable_opt="--nonative"
+fi
+
+python3 ./vcxproj_make.py --debug --binary reseekd --ccompiler "gcc -std=gnu17" $portable_opt

--- a/src/build_linux_x86p.bash
+++ b/src/build_linux_x86p.bash
@@ -8,9 +8,9 @@ curl -fsSL "https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxpr
 
 mkdir -p ../bin
 
-portable_opt=""
+cmd=(python3 ./vcxproj_make.py --profile --binary reseekp --ccompiler "gcc -std=gnu17")
 if [ "${PORTABLE:-0}" = "1" ]; then
-  portable_opt="--nonative"
+  cmd+=(--nonative --cppcompiler "g++ -mavx2")
 fi
 
-python3 ./vcxproj_make.py --profile --binary reseekp --ccompiler "gcc -std=gnu17" $portable_opt
+"${cmd[@]}"

--- a/src/build_linux_x86p.bash
+++ b/src/build_linux_x86p.bash
@@ -1,8 +1,16 @@
-commit=`cat vcxproj_make_commit.txt`
+#!/usr/bin/env bash
+set -euo pipefail
 
-curl -fsSL https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxproj_make.py \
+commit=$(cat vcxproj_make_commit.txt)
+
+curl -fsSL "https://raw.githubusercontent.com/rcedgar/vcxproj_make/$commit/vcxproj_make.py" \
   > vcxproj_make.py
 
 mkdir -p ../bin
 
-python3 ./vcxproj_make.py --profile --binary reseekp
+portable_opt=""
+if [ "${PORTABLE:-0}" = "1" ]; then
+  portable_opt="--nonative"
+fi
+
+python3 ./vcxproj_make.py --profile --binary reseekp --ccompiler "gcc -std=gnu17" $portable_opt


### PR DESCRIPTION
This PR updates the Linux build scripts and workflow to address two compilation issues (#26 and #28)

In the CI we now set `PORTABLE=1`, and the Linux build scripts use that to enable a non-native compilation mode that disables `-march=native`. This should prevent the binary from being optimized for the specific CPU of the GitHub runner, so release builds are less likely to crash with illegal-instruction errors.

In addition, the compiler is evoked with `-std=gnu17`, which avoids build errors from newer GCC defaults when compiling the `zlib` code that uses old-style function definitions.

Finally, workflow actions were updated to current major versions.